### PR TITLE
Add filter search bar to listing pages

### DIFF
--- a/src/m3c.css
+++ b/src/m3c.css
@@ -94,6 +94,11 @@ a:visited {
 /* Orange #bc581a
 Blue #00529b */
 
+#nameFilter{
+    width: 50%;
+    font-size: 1em;
+}
+
 .listing .facet {
     background-color: white;
     box-shadow: 3px 4px 5px gray;

--- a/src/organizations.html
+++ b/src/organizations.html
@@ -23,6 +23,28 @@
     <script crossorigin src="https://unpkg.com/whatwg-fetch@3.0.0/dist/fetch.umd.js"></script>
     <!-- URL polyfill to support Internet Explorer -->
     <script crossorigin src="https://unpkg.com/@ungap/url-search-params@0.1.2/min.js"></script>
+    <!-- Filters list using search bar -->
+    <script>
+        function FilterResult() {
+            var input, filter, ol, li, a, i, txtValue;
+            input = document.getElementById('nameFilter');
+            filter = input.value.toUpperCase();
+            ol = document.getElementsByClassName('results');
+            li = document.getElementsByClassName('organization');
+
+            // Loop throught list items and hide those that don't match
+            for (i = 0; i < li.length; i++) {
+                a = li[i].getElementsByTagName("a")[0];
+                txtValue = a.textContent || a.innerText;
+                if (txtValue.toUpperCase().indexOf(filter) > -1) {
+                    li[i].style.display = "";
+                } else {
+                    li[i].style.display = "none";
+                }
+            }
+
+        }
+    </script>
 
     <style>
         .type .show,
@@ -91,6 +113,9 @@
             <div id="listing">
                 <div class="controls">
                     <div class="fa fa-spinner fa-spin hidden"></div>
+                    <br>
+                    <i class="fas fa-search"></i>
+                    <input type="text" id="nameFilter" onkeyup="FilterResult()" placeholder="Search for organization">
                     <div class="count"></div>
                     <a href="#" class="reverse">Reverse</a>
                 </div>
@@ -168,6 +193,9 @@
             ctrlReverse.addEventListener("click", onCtrlReverseClick)
 
             ui.SortedList(facets.querySelector(".type ul"), -1, sortByCount)
+
+            // Filter results
+            document.getElementById("nameFilter").addEventListener("keyup", filterResult)
 
             // Query the TPF server for all organizations and some related data.
             const data = {
@@ -295,6 +323,32 @@
              */
             function sortByCount(li) {
                 return parseInt(li.querySelector(".count").innerText)
+            }
+
+            /**
+            * Filter list according to search bar
+            */
+            function filterResult() {
+                var input, filter, ol, li, a, i, txtValue;
+                input = document.getElementById('nameFilter');
+                filter = input.value.toUpperCase();
+                ol = document.getElementsByClassName('results');
+                li = document.getElementsByClassName('organization');
+
+                // Loop throught list items and hide those that don't match
+                var count = 0;
+                for (i = 0; i < li.length; i++) {
+                    a = li[i].getElementsByTagName("a")[0];
+                    txtValue = a.textContent || a.innerText;
+                    if (txtValue.toUpperCase().indexOf(filter) > -1) {
+                        li[i].style.display = "";
+                        count++;
+                    } else {
+                        li[i].style.display = "none";
+                    }
+                }
+                document.querySelector(".controls .count").innerText = String(count);
+
             }
         </script>
     </div>

--- a/src/people.html
+++ b/src/people.html
@@ -80,6 +80,9 @@
             <div id="listing">
                 <div class="controls">
                     <div class="fa fa-spinner fa-spin hidden"></div>
+                    <br>
+                    <i class="fas fa-search"></i>
+                    <input type="text" id="nameFilter" placeholder="Search for name">
                     <div class="count"></div>
                     <a href="#" class="reverse">Reverse</a>
                 </div>
@@ -153,6 +156,9 @@
             ctrlReverse.addEventListener("click", onCtrlReverseClick)
 
             ui.SortedList(facets.querySelector(".organization ul"), -1, sortByCount)
+
+            // Filter results
+            document.getElementById("nameFilter").addEventListener("keypress", filterResult)
 
             // Query the TPF server for all people and some related data.
             const data = {
@@ -294,6 +300,32 @@
              */
             function sortByCount(li) {
                 return parseInt(li.querySelector(".count").innerText)
+            }
+
+            /**
+            * Filter list according to search bar
+            */
+            function filterResult() {
+                var input, filter, ol, li, a, i, txtValue;
+                input = document.getElementById('nameFilter');
+                filter = input.value.toUpperCase();
+                ol = document.getElementsByClassName('results');
+                li = document.getElementsByClassName('person');
+
+                // Loop throught list items and hide those that don't match
+                var count = 0;
+                for (i = 0; i < li.length; i++) {
+                    a = li[i].getElementsByTagName("a")[0];
+                    txtValue = a.textContent || a.innerText;
+                    if (txtValue.toUpperCase().indexOf(filter) > -1) {
+                        li[i].style.display = "";
+                        count++;
+                    } else {
+                        li[i].style.display = "none";
+                    }
+                }
+                document.querySelector(".controls .count").innerText = String(count);
+
             }
         </script>
     </div>

--- a/src/projects.html
+++ b/src/projects.html
@@ -23,6 +23,28 @@
     <script crossorigin src="https://unpkg.com/whatwg-fetch@3.0.0/dist/fetch.umd.js"></script>
     <!-- URL polyfill to support Internet Explorer -->
     <script crossorigin src="https://unpkg.com/@ungap/url-search-params@0.1.2/min.js"></script>
+    <!-- Filters list using search bar -->
+    <script>
+        function FilterResult() {
+            var input, filter, ol, li, a, i, txtValue;
+            input = document.getElementById('nameFilter');
+            filter = input.value.toUpperCase();
+            ol = document.getElementsByClassName('results');
+            li = document.getElementsByClassName('project');
+
+            // Loop throught list items and hide those that don't match
+            for (i = 0; i < li.length; i++) {
+                a = li[i].getElementsByTagName("a")[0];
+                txtValue = a.textContent || a.innerText;
+                if (txtValue.toUpperCase().indexOf(filter) > -1) {
+                    li[i].style.display = "";
+                } else {
+                    li[i].style.display = "none";
+                }
+            }
+
+        }
+    </script>
 
 </head>
 
@@ -70,6 +92,9 @@
             <div id="listing">
                 <div class="controls">
                     <div class="fa fa-spinner fa-spin hidden"></div>
+                    <br>
+                    <i class="fas fa-search"></i>
+                    <input type="text" id="nameFilter" onkeyup="FilterResult()" placeholder="Search for project">
                     <div class="count"></div>
                     <a href="#" class="reverse">Reverse</a>
                 </div>
@@ -138,6 +163,9 @@
             ctrlReverse.addEventListener("click", onCtrlReverseClick)
 
             ui.SortedList(facets.querySelector(".organization ul"), -1, sortByCount)
+
+            // Filter results
+            document.getElementById("nameFilter").addEventListener("keyup", filterResult)
 
             // Query the TPF server for all projects and some related data.
             const data = {
@@ -251,6 +279,32 @@
              */
             function sortByCount(li) {
                 return parseInt(li.querySelector(".count").innerText)
+            }
+
+            /**
+            * Filter list according to search bar
+            */
+            function filterResult() {
+                var input, filter, ol, li, a, i, txtValue;
+                input = document.getElementById('nameFilter');
+                filter = input.value.toUpperCase();
+                ol = document.getElementsByClassName('results');
+                li = document.getElementsByClassName('project');
+
+                // Loop throught list items and hide those that don't match
+                var count = 0;
+                for (i = 0; i < li.length; i++) {
+                    a = li[i].getElementsByTagName("a")[0];
+                    txtValue = a.textContent || a.innerText;
+                    if (txtValue.toUpperCase().indexOf(filter) > -1) {
+                        li[i].style.display = "";
+                        count++;
+                    } else {
+                        li[i].style.display = "none";
+                    }
+                }
+                document.querySelector(".controls .count").innerText = String(count);
+
             }
         </script>
     </div>

--- a/src/publications.html
+++ b/src/publications.html
@@ -23,6 +23,28 @@
     <script crossorigin src="https://unpkg.com/whatwg-fetch@3.0.0/dist/fetch.umd.js"></script>
     <!-- URL polyfill to support Internet Explorer -->
     <script crossorigin src="https://unpkg.com/@ungap/url-search-params@0.1.2/min.js"></script>
+    <!-- Filters list using search bar -->
+    <script>
+        function FilterResult() {
+            var input, filter, ol, li, a, i, txtValue;
+            input = document.getElementById('nameFilter');
+            filter = input.value.toUpperCase();
+            ol = document.getElementsByClassName('results');
+            li = document.getElementsByClassName('publication');
+
+            // Loop throught list items and hide those that don't match
+            for (i = 0; i < li.length; i++) {
+                a = li[i].getElementsByTagName("a")[0];
+                txtValue = a.textContent || a.innerText;
+                if (txtValue.toUpperCase().indexOf(filter) > -1) {
+                    li[i].style.display = "";
+                } else {
+                    li[i].style.display = "none";
+                }
+            }
+
+        }
+    </script>
 
     <style>
         .disclaimer {
@@ -76,6 +98,9 @@
             <div id="listing">
                 <div class="controls">
                     <div class="fa fa-spinner fa-spin hidden"></div>
+                    <br>
+                    <i class="fas fa-search"></i>
+                    <input type="text" id="nameFilter" onkeyup="FilterResult()" placeholder="Search for publication">
                     <div class="count"></div>
                     <a href="#" class="reverse">Reverse</a>
                 </div>
@@ -172,6 +197,9 @@
 
             ui.SortedList(facets.querySelector(".published ul"), -1, sortByName)
             ui.SortedList(facets.querySelector(".author ul"), -1, sortByCount)
+
+            // Filter results
+            document.getElementById("nameFilter").addEventListener("keyup", filterResult)
 
             // Query the TPF server for all publications and some related data.
             const data = {
@@ -365,6 +393,32 @@
              */
             function sortByCount(li) {
                 return parseInt(li.querySelector(".count").innerText)
+            }
+
+            /**
+            * Filter list according to search bar
+            */
+            function filterResult() {
+                var input, filter, ol, li, a, i, txtValue;
+                input = document.getElementById('nameFilter');
+                filter = input.value.toUpperCase();
+                ol = document.getElementsByClassName('results');
+                li = document.getElementsByClassName('publication');
+
+                // Loop throught list items and hide those that don't match
+                var count = 0;
+                for (i = 0; i < li.length; i++) {
+                    a = li[i].getElementsByTagName("a")[0];
+                    txtValue = a.textContent || a.innerText;
+                    if (txtValue.toUpperCase().indexOf(filter) > -1) {
+                        li[i].style.display = "";
+                        count++;
+                    } else {
+                        li[i].style.display = "none";
+                    }
+                }
+                document.querySelector(".controls .count").innerText = String(count);
+
             }
         </script>
     </div>

--- a/src/studies.html
+++ b/src/studies.html
@@ -23,6 +23,28 @@
     <script crossorigin src="https://unpkg.com/whatwg-fetch@3.0.0/dist/fetch.umd.js"></script>
     <!-- URL polyfill to support Internet Explorer -->
     <script crossorigin src="https://unpkg.com/@ungap/url-search-params@0.1.2/min.js"></script>
+    <!-- Filters list using search bar -->
+    <script>
+        function FilterResult() {
+            var input, filter, ol, li, a, i, txtValue;
+            input = document.getElementById('nameFilter');
+            filter = input.value.toUpperCase();
+            ol = document.getElementsByClassName('results');
+            li = document.getElementsByClassName('study');
+
+            // Loop throught list items and hide those that don't match
+            for (i = 0; i < li.length; i++) {
+                a = li[i].getElementsByTagName("a")[0];
+                txtValue = a.textContent || a.innerText;
+                if (txtValue.toUpperCase().indexOf(filter) > -1) {
+                    li[i].style.display = "";
+                } else {
+                    li[i].style.display = "none";
+                }
+            }
+
+        }
+    </script>
 
 </head>
 
@@ -70,6 +92,9 @@
             <div id="listing">
                 <div class="controls">
                     <div class="fa fa-spinner fa-spin hidden"></div>
+                    <br>
+                    <i class="fas fa-search"></i>
+                    <input type="text" id="nameFilter" onkeyup="FilterResult()" placeholder="Search for study">
                     <div class="count"></div>
                     <a href="#" class="reverse">Reverse</a>
                 </div>
@@ -138,6 +163,9 @@
             ctrlReverse.addEventListener("click", onCtrlReverseClick)
 
             ui.SortedList(facets.querySelector(".submitted ul"), -1, sortByName)
+
+            // Filter results
+            document.getElementById("nameFilter").addEventListener("keyup", filterResult)
 
             // Query the TPF server for all studies and some related data.
             const data = {
@@ -243,6 +271,32 @@
             function sortByName(li) {
                 const name = li.querySelector(".name").innerText.toUpperCase()
                 return name
+            }
+
+            /**
+            * Filter list according to search bar
+            */
+            function filterResult() {
+                var input, filter, ol, li, a, i, txtValue;
+                input = document.getElementById('nameFilter');
+                filter = input.value.toUpperCase();
+                ol = document.getElementsByClassName('results');
+                li = document.getElementsByClassName('study');
+
+                // Loop throught list items and hide those that don't match
+                var count = 0;
+                for (i = 0; i < li.length; i++) {
+                    a = li[i].getElementsByTagName("a")[0];
+                    txtValue = a.textContent || a.innerText;
+                    if (txtValue.toUpperCase().indexOf(filter) > -1) {
+                        li[i].style.display = "";
+                        count++;
+                    } else {
+                        li[i].style.display = "none";
+                    }
+                }
+                document.querySelector(".controls .count").innerText = String(count);
+
             }
         </script>
     </div>

--- a/src/tools.html
+++ b/src/tools.html
@@ -23,6 +23,28 @@
     <script crossorigin src="https://unpkg.com/whatwg-fetch@3.0.0/dist/fetch.umd.js"></script>
     <!-- URL polyfill to support Internet Explorer -->
     <script crossorigin src="https://unpkg.com/@ungap/url-search-params@0.1.2/min.js"></script>
+    <!-- Filters list using search bar -->
+    <script>
+        function FilterResult() {
+            var input, filter, ol, li, a, i, txtValue;
+            input = document.getElementById('nameFilter');
+            filter = input.value.toUpperCase();
+            ol = document.getElementsByClassName('results');
+            li = document.getElementsByClassName('tool');
+
+            // Loop throught list items and hide those that don't match
+            for (i = 0; i < li.length; i++) {
+                a = li[i].getElementsByTagName("a")[0];
+                txtValue = a.textContent || a.innerText;
+                if (txtValue.toUpperCase().indexOf(filter) > -1) {
+                    li[i].style.display = "";
+                } else {
+                    li[i].style.display = "none";
+                }
+            }
+
+        }
+    </script>
 
     <style>
         .tags div {
@@ -81,6 +103,9 @@
             <div id="listing">
                 <div class="controls">
                     <div class="fa fa-spinner fa-spin hidden"></div>
+                    <br>
+                    <i class="fas fa-search"></i>
+                    <input type="text" id="nameFilter" onkeyup="FilterResult()" placeholder="Search for tool">
                     <div class="count"></div>
                     <a href="#" class="reverse">Reverse</a>
                 </div>
@@ -151,6 +176,9 @@
             ctrlReverse.addEventListener("click", onCtrlReverseClick)
 
             ui.SortedList(facets.querySelector(".tag ul"), -1, sortByCount)
+
+            // Filter results
+            document.getElementById("nameFilter").addEventListener("keyup", filterResult)
 
             // Query the TPF server for all tools and some related data.
             const data = {
@@ -275,6 +303,32 @@
             function sortByName(li) {
                 const name = li.querySelector(".name").innerText.toUpperCase()
                 return name
+            }
+
+            /**
+            * Filter list according to search bar
+            */
+            function filterResult() {
+                var input, filter, ol, li, a, i, txtValue;
+                input = document.getElementById('nameFilter');
+                filter = input.value.toUpperCase();
+                ol = document.getElementsByClassName('results');
+                li = document.getElementsByClassName('tool');
+
+                // Loop throught list items and hide those that don't match
+                var count = 0;
+                for (i = 0; i < li.length; i++) {
+                    a = li[i].getElementsByTagName("a")[0];
+                    txtValue = a.textContent || a.innerText;
+                    if (txtValue.toUpperCase().indexOf(filter) > -1) {
+                        li[i].style.display = "";
+                        count++;
+                    } else {
+                        li[i].style.display = "none";
+                    }
+                }
+                document.querySelector(".controls .count").innerText = String(count);
+
             }
         </script>
     </div>


### PR DESCRIPTION
**What does this change do?** 

Add a search bar to filter results on listing pages. Also update the count when filtering.

**Why was this change made?** _Including an issue number is sufficient. Otherwise, briefly explain the benefit of the change._

Make listing pages less overwhelming and allow users to easily find particular people, organizations, etc.


## Verification

_List the steps needed to make sure this thing works. Be precise._

1. Open any of the Listing pages
2. Filter the results by typing into the search bar
3. Behold the number under Count changing

### Screenshots

<img width="990" alt="Screen Shot 2019-10-24 at 2 07 32 PM" src="https://user-images.githubusercontent.com/23503760/67512982-ed9c0400-f667-11e9-91e9-013c73ad885f.png">

<img width="978" alt="Screen Shot 2019-10-24 at 2 07 39 PM" src="https://user-images.githubusercontent.com/23503760/67512975-e96fe680-f667-11e9-80f0-f3b3a8a6ba14.png">

### Browsers Checked

- [x] Chrome 77.0.3865.120 on macOS High Sierra
- [X] Firefox 69.0.3 on macOS High Sierra
- [X] Internet Explorer 11 on Windows 7


## Affirmations

All of these should have a check by them. Any exception requires an explanation.

* [X] I matched the style of the existing code.
* [X] I used JSDocs JSDocs-based type hinting.
* [X] I have written the code myself or have given credit where credit is due.
* [X] I added and updated any relevant documentation such as the `README` or `CHANGELOG`?
* [X] I have made an effort to minimize code changes and have not included any cruft (old comments, print-debugging, unused variables).
* [X] I have made an effort maintain a clear commit history (haven't merged other branches or rebased improperly).
