### PR TITLE
Change people page to pull all profile pictures in one request.

### DIFF
--- a/src/entity.js
+++ b/src/entity.js
@@ -84,6 +84,18 @@ var entity = (function module() {
         })
     }
 
+    function MainImages(client) {
+        return client.MapAll(vitro + "mainImage")
+    }
+
+    function DownloadLocations(client) {
+        return client.MapAll(vitro + "downloadLocation")
+    }
+
+    function DirectDownloadUrls(client) {
+        return client.MapAll(vitro + "directDownloadUrl")
+    }
+
     /**
      * Fetches the name (label) of an Entity.
      *
@@ -433,7 +445,6 @@ var entity = (function module() {
                 client
                     .Entity(iri)
                     .Link(vitro, "mainImage")
-                    .Link(vitro, "thumbnailImage")
                     .Link(vitro, "downloadLocation")
                     .Link(vitro, "directDownloadUrl")
                     .Single(decodeString(returnPhoto))
@@ -995,9 +1006,12 @@ var entity = (function module() {
         Authorships: Authorships,
         Citations: Citations,
         Departments: Departments,
+        DirectDownloadUrls: DirectDownloadUrls,
+        DownloadLocations: DownloadLocations,
         FundingOrganizations: FundingOrganizations,
         Institutes: Institutes,
         Laboratories: Laboratories,
+        MainImages: MainImages,
         Name: Name,
         Names: Names,
         Organization: Organization,

--- a/src/people.html
+++ b/src/people.html
@@ -186,7 +186,11 @@
                 person: [],
                 associatedWith: {},  // person IRI => org IRI
                 names: {},           // entity IRI => label string
-                institutes: []       // list of institute IRIs
+                institutes: [],       // list of institute IRIs
+                mainImages: {},
+                downloadLocations: {},
+                directDownloadUrls: {},
+                personToURL: {}
             }
 
             const promises = [
@@ -194,6 +198,9 @@
                 entity.AssociatedWiths(client),
                 entity.Names(client),
                 entity.Institutes(client),
+                entity.MainImages(client),
+                entity.DownloadLocations(client),
+                entity.DirectDownloadUrls(client)
             ]
 
             Promise.all(promises)
@@ -202,6 +209,20 @@
                     data.associatedWith = results[1]
                     data.names = results[2]
                     data.institutes = results[3]
+                    data.mainImages = results[4]
+                    data.downloadLocations = results[5]
+                    data.directDownloadUrls = results[6]
+
+                    data.person.forEach(function(uri) {
+                        const mainImage = data.mainImages[uri]
+                        if (!mainImage) {
+                            return
+                        }
+
+                        const downloadLocation = data.downloadLocations[mainImage]
+                        const directURL = data.directDownloadUrls[downloadLocation]
+                        data.personToURL[uri] = directURL[0].slice(1, -1)
+                    })
 
                     data.person.forEach(renderPerson)
                 })
@@ -268,15 +289,11 @@
                 }
 
                 function getPhoto(callback) {
-                    person.PhotoThumbnail(renderPhoto)
-
-                    function renderPhoto(url) {
-                        if (!url) {
-                            return
-                        }
-                        url = m3c.PhotoURL(client.Endpoint, url)
-                        callback(url)
+                    const url = data.personToURL[personIRI]
+                    if (!url) {
+                        return
                     }
+                    callback(m3c.PhotoURL(client.Endpoint, url))
                 }
             }
 


### PR DESCRIPTION
**What does this change do?** _Please be clear and concise._

Change the people page to request all profile pictures in one request to reduce the amount of requests by 4 for each person. The frontend now maps the pictures to the profile and replaces the picture.

**Why was this change made?** _Including an issue number is sufficient. Otherwise, briefly explain the benefit of the change._

SEP-168

## Verification

_List the steps needed to make sure this thing works. Be precise._

1. From the main page, I clicked on the "People" link.
2. On the People Listing, verify that there are profile pictures.

### Screenshots

Before:
![image](https://user-images.githubusercontent.com/3639154/76424791-130f7d00-637f-11ea-967a-074c4b29037a.png)
![image](https://user-images.githubusercontent.com/3639154/76424880-389c8680-637f-11ea-939d-a84a4d91e6c4.png)

After:

![image](https://user-images.githubusercontent.com/3639154/76424813-1c004e80-637f-11ea-8189-ef7510715511.png)
![image](https://user-images.githubusercontent.com/3639154/76424904-3f2afe00-637f-11ea-9643-25ca8fad81ef.png)

### Browsers Checked

None.

- [x] Chrome 77.0.3865.120 on macOS High Sierra
- [x] Firefox 69.0.3 on macOS High Sierra
- [ ] Internet Explorer 11 on Windows 10


## Affirmations

All of these should have a check by them. Any exception requires an explanation.

* [x] I matched the style of the existing code.
* [x] I used JSDocs for documentation and JSDocs-based type hinting.
* [x] I have written the code myself or have given credit where credit is due.
* [x] I added and updated any relevant documentation such as the `README` or `CHANGELOG`?
* [x] I have made an effort to minimize code changes and have not included any cruft (old comments, print-debugging, unused variables).
* [x] I have made an effort maintain a clear commit history (haven't merged other branches or rebased improperly).
